### PR TITLE
containerize with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/library/python:3.12.3-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     environment:
       - MONGODB_URI=${MONGODB_URI} # default: mongodb://host.docker.internal:27017
       - NEO4J_URI=bolt://neo4j:7687
+    ports:
+      - "5000:5000"
     depends_on:
       neo4j:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  neo4j:
+    image: docker.io/library/neo4j:latest
+    environment:
+      - NEO4J_AUTH=none
+      - NEO4J_PLUGINS=["graph-data-science"]
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7474/"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  ublog:
+    build: .
+    environment:
+      - MONGODB_URI=${MONGODB_URI} # default: mongodb://host.docker.internal:27017
+      - NEO4J_URI=bolt://neo4j:7687
+    depends_on:
+      neo4j:
+        condition: service_healthy

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 from flask import Flask, abort
 from pymongo import MongoClient
 from neo4j import GraphDatabase
+import os
 import threading
 import logging
 from apscheduler.schedulers.background import BlockingScheduler
@@ -16,16 +17,16 @@ logging.basicConfig(
     level=logging.INFO,
     datefmt='%Y-%m-%d %H:%M:%S')
 
+logger.info("Starting up...")
+
 # establish connections
-mongo_client = MongoClient('mongodb://localhost:27017/')
+mongo_uri = os.environ.get("MONGODB_URI") or "mongodb://host.docker.internal:27017/"
+mongo_client = MongoClient(mongo_uri)
 mongo_db = mongo_client['lichess']
 mongo_collection = mongo_db["ublog_post"]
 
-neo4j_url = "bolt://localhost:7687"
-neo4j_username = "neo4j"
-neo4j_password = "your_neo4j_password"
-
-neo4j_driver = GraphDatabase.driver(neo4j_url, auth=(neo4j_username, neo4j_password))
+neo4j_url = os.environ.get("NEO4J_URI") or "bolt://host.docker.internal:7687"
+neo4j_driver = GraphDatabase.driver(neo4j_url)
 neo4j_session = neo4j_driver.session()
 
 # set up API routes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dnspython==2.7.0
 neo4j==5.27.0
 pymongo==4.10.1
+tqdm==4.67.1
 pytz==2024.2
 APScheduler==3.11.0
 Flask==3.1.0


### PR DESCRIPTION
first cd to the repo root so that ./docker-compose.yml and ./Dockerfile can be found
```
cd lila-blogrecommender
```

### to startup containers if mongodb is running on localhost:27017:
```
docker compose up
```
### or for external mongodb <mongohost>
```
MONGODB_URI=mongodb://<mongohost>:27017 docker compose up
```

### to stop
```
docker compose down
```

podman is the same but you use `podman-compose` rather than `docker compose`

